### PR TITLE
Enable backend websocket updates

### DIFF
--- a/server2/api/websocket.py
+++ b/server2/api/websocket.py
@@ -1,0 +1,53 @@
+from typing import List
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import asyncio
+from utils.database import get_anomalies, get_traffic
+from utils.logger import get_logger
+
+logger = get_logger()
+router = APIRouter()
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info("WebSocket connected")
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+        logger.info("WebSocket disconnected")
+
+    async def broadcast(self, message: dict):
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_json(message)
+            except Exception as e:
+                logger.error(f"Error sending message: {e}")
+
+manager = ConnectionManager()
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    last_anomaly_id = None
+    try:
+        while True:
+            await asyncio.sleep(5)
+            anomalies = get_anomalies(limit=1)
+            if anomalies:
+                latest = anomalies[0]
+                if last_anomaly_id != latest["anomaly_id"]:
+                    await websocket.send_json({"event": "anomaly_alert", "data": latest})
+                    last_anomaly_id = latest["anomaly_id"]
+            traffic = get_traffic(limit=1)
+            if traffic:
+                await websocket.send_json({"event": "data_update", "data": traffic[0]})
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+        manager.disconnect(websocket)

--- a/server2/main.py
+++ b/server2/main.py
@@ -24,6 +24,7 @@ from api.models import ErrorResponse
 from api.alerts_routes import router as alerts_router
 from api.statistics_routes import router as statistics_router
 from api.model_routes import router as model_router
+from api.websocket import router as websocket_router
 
 # Setup logging
 logger = setup_logger()
@@ -82,6 +83,7 @@ app.include_router(scheduler_router, prefix="/api/v1")
 app.include_router(alerts_router, prefix="/api/v1")
 app.include_router(statistics_router, prefix="/api/v1")
 app.include_router(model_router, prefix="/api/v1")
+app.include_router(websocket_router)
 
 # Define Pydantic models for request/response validation
 class Device(BaseModel):

--- a/src/components/KPIDashboard/index.tsx
+++ b/src/components/KPIDashboard/index.tsx
@@ -64,17 +64,7 @@ const KPIDashboard: React.FC = () => {
       setError(null);
     } catch (err) {
       console.error('Error fetching KPI data:', err);
-      
-      // Use mock data if API fails
-      setKpiData({
-        packetsPerSecond: 245,
-        anomaliesToday: 12,
-        devicesOnline: 8,
-        totalTraffic: 1254,
-        detectionAccuracy: 92.5
-      });
-      
-      setError('Using sample data - API connection failed');
+      setError('Failed to load KPI data');
     } finally {
       setLoading(false);
     }

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -1,120 +1,40 @@
-// Mock socket service since the Python backend doesn't support WebSockets yet
-import api from './api';
-
 class SocketService {
-  private connected: boolean = false;
+  private ws: WebSocket | null = null;
   private listeners: Map<string, Set<(data: any) => void>> = new Map();
-  private pollingInterval: number | null = null;
-  private lastAnomalyCount: number = 0;
-  private simulationInterval: number | null = null;
 
-  // Initialize connection
   connect() {
-    if (this.connected) return;
-    this.connected = true;
-    console.log('Socket simulation started');
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
 
-    // Start polling for anomalies every 10 seconds
-    this.pollingInterval = window.setInterval(() => {
-      this.pollForAnomalies();
-    }, 10000);
+    this.ws = new WebSocket('ws://localhost:5000/ws');
 
-    // Simulate data updates every 5 seconds
-    this.simulationInterval = window.setInterval(() => {
-      this.simulateDataUpdates();
-    }, 5000);
-  }
+    this.ws.onopen = () => {
+      console.log('WebSocket connected');
+    };
 
-  // Disconnect
-  disconnect() {
-    this.connected = false;
-    if (this.pollingInterval) {
-      window.clearInterval(this.pollingInterval);
-      this.pollingInterval = null;
-    }
-    if (this.simulationInterval) {
-      window.clearInterval(this.simulationInterval);
-      this.simulationInterval = null;
-    }
-    console.log('Socket simulation stopped');
-  }
-
-  // Poll for new anomalies
-  private async pollForAnomalies() {
-    if (!this.connected) return;
-
-    try {
-      const anomalies = await api.fetchAnomalies();
-      
-      // Check if we have new anomalies
-      if (anomalies.length > this.lastAnomalyCount) {
-        // Get new anomalies
-        const newAnomalies = anomalies.slice(0, anomalies.length - this.lastAnomalyCount);
-        
-        // Notify listeners about each new anomaly
-        newAnomalies.forEach((anomaly: any) => {
-          this.notifyListeners('anomaly_alert', anomaly);
-        });
-        
-        this.lastAnomalyCount = anomalies.length;
-      }
-    } catch (error) {
-      console.error('Error polling for anomalies:', error);
-    }
-  }
-
-  // Simulate real-time data updates
-  private simulateDataUpdates() {
-    if (!this.connected) return;
-
-    // Generate a mock data update
-    const mockData = {
-      id: Math.floor(Math.random() * 50).toString(), // Random device ID between 0-49
-      timestamp: new Date().toISOString(),
-      temperature: 20 + Math.random() * 10,
-      humidity: 30 + Math.random() * 40,
-      pressure: 900 + Math.random() * 200,
-      vibration: Math.random() * 5,
-      status: Math.random() > 0.9 ? 'anomaly' : 'normal',
-      network: {
-        packetLoss: Math.random() * 5,
-        latency: 10 + Math.random() * 100,
-        throughput: 100 + Math.random() * 900,
-        connectionCount: Math.floor(Math.random() * 10)
+    this.ws.onmessage = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.event) {
+          this.notifyListeners(msg.event, msg.data);
+        }
+      } catch (e) {
+        console.error('Invalid websocket message', e);
       }
     };
 
-    // Notify listeners
-    this.notifyListeners('data_update', mockData);
+    this.ws.onclose = () => {
+      console.log('WebSocket disconnected');
+      this.ws = null;
+    };
+  }
 
-    // Occasionally simulate a device status change
-    if (Math.random() > 0.8) {
-      const deviceStatus = {
-        deviceId: Math.floor(Math.random() * 50).toString(),
-        status: Math.random() > 0.5 ? 'online' : 'offline',
-        lastSeen: new Date().toISOString()
-      };
-      this.notifyListeners('device_status', deviceStatus);
-    }
-
-    // Occasionally simulate an anomaly
-    if (Math.random() > 0.9) {
-      const anomaly = {
-        _id: Date.now().toString(),
-        deviceId: Math.floor(Math.random() * 50).toString(),
-        timestamp: new Date().toISOString(),
-        type: Math.random() > 0.5 ? 'Isolation Forest' : 'Local Outlier Factor',
-        severity: Math.random() > 0.7 ? 'high' : Math.random() > 0.4 ? 'medium' : 'low',
-        value: Math.random(),
-        threshold: 0.5,
-        description: `Simulated anomaly detected at ${new Date().toLocaleTimeString()}`,
-        resolved: false
-      };
-      this.notifyListeners('anomaly_alert', anomaly);
+  disconnect() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
     }
   }
 
-  // Add event listener
   addEventListener(event: string, callback: (data: any) => void) {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set());
@@ -122,28 +42,20 @@ class SocketService {
     this.listeners.get(event)?.add(callback);
   }
 
-  // Remove event listener
   removeEventListener(event: string, callback: (data: any) => void) {
-    if (this.listeners.has(event)) {
-      this.listeners.get(event)?.delete(callback);
-    }
+    this.listeners.get(event)?.delete(callback);
   }
 
-  // Notify all listeners for an event
   private notifyListeners(event: string, data: any) {
-    if (this.listeners.has(event)) {
-      this.listeners.get(event)?.forEach(callback => {
-        try {
-          callback(data);
-        } catch (error) {
-          console.error(`Error in ${event} listener:`, error);
-        }
-      });
-    }
+    this.listeners.get(event)?.forEach(cb => {
+      try {
+        cb(data);
+      } catch (err) {
+        console.error(`Error in ${event} listener`, err);
+      }
+    });
   }
 }
 
-// Create singleton instance
 const socketService = new SocketService();
-
 export default socketService;


### PR DESCRIPTION
## Summary
- add FastAPI websocket route to stream data and anomalies
- connect frontend socket service to backend websockets
- drop fallback KPI sample data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851301309b4832a9931a5975b7ce6b1