### PR TITLE
Implement real WebSocket updates

### DIFF
--- a/server2/services/websocket_manager.py
+++ b/server2/services/websocket_manager.py
@@ -1,0 +1,39 @@
+import asyncio
+import json
+from typing import List
+from fastapi import WebSocket
+
+class WebSocketManager:
+    """Manages active WebSocket connections and allows broadcasting."""
+    def __init__(self) -> None:
+        self.active_connections: List[WebSocket] = []
+        self.loop: asyncio.AbstractEventLoop | None = None
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def _broadcast(self, message: dict) -> None:
+        data = json.dumps(message)
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(data)
+            except Exception:
+                # Remove broken connections
+                self.disconnect(connection)
+
+    def broadcast(self, message: dict) -> None:
+        """Broadcast a message to all clients in a thread-safe manner."""
+        if self.loop is None:
+            return
+        asyncio.run_coroutine_threadsafe(self._broadcast(message), self.loop)
+
+# Singleton instance
+manager = WebSocketManager()

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -1,120 +1,33 @@
-// Mock socket service since the Python backend doesn't support WebSockets yet
-import api from './api';
-
 class SocketService {
-  private connected: boolean = false;
+  private socket: WebSocket | null = null;
   private listeners: Map<string, Set<(data: any) => void>> = new Map();
-  private pollingInterval: number | null = null;
-  private lastAnomalyCount: number = 0;
-  private simulationInterval: number | null = null;
 
-  // Initialize connection
   connect() {
-    if (this.connected) return;
-    this.connected = true;
-    console.log('Socket simulation started');
+    if (this.socket) return;
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    this.socket = new WebSocket(`${protocol}://${window.location.host}/ws`);
 
-    // Start polling for anomalies every 10 seconds
-    this.pollingInterval = window.setInterval(() => {
-      this.pollForAnomalies();
-    }, 10000);
-
-    // Simulate data updates every 5 seconds
-    this.simulationInterval = window.setInterval(() => {
-      this.simulateDataUpdates();
-    }, 5000);
-  }
-
-  // Disconnect
-  disconnect() {
-    this.connected = false;
-    if (this.pollingInterval) {
-      window.clearInterval(this.pollingInterval);
-      this.pollingInterval = null;
-    }
-    if (this.simulationInterval) {
-      window.clearInterval(this.simulationInterval);
-      this.simulationInterval = null;
-    }
-    console.log('Socket simulation stopped');
-  }
-
-  // Poll for new anomalies
-  private async pollForAnomalies() {
-    if (!this.connected) return;
-
-    try {
-      const anomalies = await api.fetchAnomalies();
-      
-      // Check if we have new anomalies
-      if (anomalies.length > this.lastAnomalyCount) {
-        // Get new anomalies
-        const newAnomalies = anomalies.slice(0, anomalies.length - this.lastAnomalyCount);
-        
-        // Notify listeners about each new anomaly
-        newAnomalies.forEach((anomaly: any) => {
-          this.notifyListeners('anomaly_alert', anomaly);
-        });
-        
-        this.lastAnomalyCount = anomalies.length;
-      }
-    } catch (error) {
-      console.error('Error polling for anomalies:', error);
-    }
-  }
-
-  // Simulate real-time data updates
-  private simulateDataUpdates() {
-    if (!this.connected) return;
-
-    // Generate a mock data update
-    const mockData = {
-      id: Math.floor(Math.random() * 50).toString(), // Random device ID between 0-49
-      timestamp: new Date().toISOString(),
-      temperature: 20 + Math.random() * 10,
-      humidity: 30 + Math.random() * 40,
-      pressure: 900 + Math.random() * 200,
-      vibration: Math.random() * 5,
-      status: Math.random() > 0.9 ? 'anomaly' : 'normal',
-      network: {
-        packetLoss: Math.random() * 5,
-        latency: 10 + Math.random() * 100,
-        throughput: 100 + Math.random() * 900,
-        connectionCount: Math.floor(Math.random() * 10)
+    this.socket.onmessage = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data);
+        this.notifyListeners(msg.event, msg.data);
+      } catch (err) {
+        console.error('Invalid WebSocket message', err);
       }
     };
 
-    // Notify listeners
-    this.notifyListeners('data_update', mockData);
+    this.socket.onclose = () => {
+      this.socket = null;
+    };
+  }
 
-    // Occasionally simulate a device status change
-    if (Math.random() > 0.8) {
-      const deviceStatus = {
-        deviceId: Math.floor(Math.random() * 50).toString(),
-        status: Math.random() > 0.5 ? 'online' : 'offline',
-        lastSeen: new Date().toISOString()
-      };
-      this.notifyListeners('device_status', deviceStatus);
-    }
-
-    // Occasionally simulate an anomaly
-    if (Math.random() > 0.9) {
-      const anomaly = {
-        _id: Date.now().toString(),
-        deviceId: Math.floor(Math.random() * 50).toString(),
-        timestamp: new Date().toISOString(),
-        type: Math.random() > 0.5 ? 'Isolation Forest' : 'Local Outlier Factor',
-        severity: Math.random() > 0.7 ? 'high' : Math.random() > 0.4 ? 'medium' : 'low',
-        value: Math.random(),
-        threshold: 0.5,
-        description: `Simulated anomaly detected at ${new Date().toLocaleTimeString()}`,
-        resolved: false
-      };
-      this.notifyListeners('anomaly_alert', anomaly);
+  disconnect() {
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
     }
   }
 
-  // Add event listener
   addEventListener(event: string, callback: (data: any) => void) {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set());
@@ -122,28 +35,20 @@ class SocketService {
     this.listeners.get(event)?.add(callback);
   }
 
-  // Remove event listener
   removeEventListener(event: string, callback: (data: any) => void) {
-    if (this.listeners.has(event)) {
-      this.listeners.get(event)?.delete(callback);
-    }
+    this.listeners.get(event)?.delete(callback);
   }
 
-  // Notify all listeners for an event
   private notifyListeners(event: string, data: any) {
-    if (this.listeners.has(event)) {
-      this.listeners.get(event)?.forEach(callback => {
-        try {
-          callback(data);
-        } catch (error) {
-          console.error(`Error in ${event} listener:`, error);
-        }
-      });
-    }
+    this.listeners.get(event)?.forEach(cb => {
+      try {
+        cb(data);
+      } catch (err) {
+        console.error(`Error in ${event} listener`, err);
+      }
+    });
   }
 }
 
-// Create singleton instance
 const socketService = new SocketService();
-
 export default socketService;


### PR DESCRIPTION
## Summary
- add a WebSocket manager service on the backend
- expose `/ws` endpoint in FastAPI app
- broadcast MQTT data and anomalies to all WebSocket clients
- switch frontend socket service to use real WebSockets

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851f6c5c8d0832a8ce56d342cc373c0