### PR TITLE
Add environment config to client

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+VITE_API_URL=http://localhost:5000/api/v1
+VITE_WS_URL=ws://localhost:5000/ws
+

--- a/client/README.md
+++ b/client/README.md
@@ -36,6 +36,17 @@ cd iot-anomaly-monitor
 npm install
 ```
 
+### Environment Variables
+
+Create a `.env` file in the `client` directory with the following variables or copy and rename `.env.example`:
+
+```
+VITE_API_URL=http://localhost:5000/api/v1
+VITE_WS_URL=ws://localhost:5000/ws
+```
+
+These values configure the backend API endpoint and WebSocket server used by the frontend.
+
 3. Run the development server:
 ```
 npm start

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -50,8 +50,8 @@ interface AggregatedData {
 
 // Using FormattedAnomaly from shared types
 
-// Using relative path for proxy to avoid CORS issues
-const API_URL = '/api/v1';
+// Use API URL from environment variables. Defaults to the proxy path.
+const API_URL = import.meta.env.VITE_API_URL || '/api/v1';
 
 // Create axios instance with case converter middleware
 const api = applyCaseMiddleware(axios.create({

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -5,7 +5,8 @@ class SocketService {
   connect() {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
 
-    this.ws = new WebSocket('ws://localhost:5000/ws');
+    const url = import.meta.env.VITE_WS_URL || 'ws://localhost:5000/ws';
+    this.ws = new WebSocket(url);
 
     this.ws.onopen = () => {
       console.log('WebSocket connected');

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,29 +1,33 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5000',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL?.replace(/\/api\/v1$/, '') || 'http://localhost:5000',
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path
+        }
       }
+    },
+    build: {
+      outDir: 'build',
+    },
+    resolve: {
+      alias: [
+        {
+          find: '@',
+          replacement: '/src',
+        },
+      ]
     }
-  },
-  build: {
-    outDir: 'build',
-  },
-  resolve: {
-    alias: [
-      {
-        find: '@',
-        replacement: '/src',
-      },
-    ]
-  }
+  };
 });


### PR DESCRIPTION
## Summary
- load environment variables in `vite.config.ts`
- read API URL and WebSocket URL from `import.meta.env`
- document environment variables
- provide `.env.example`

## Testing
- `npm test --prefix client` *(fails: Missing script)*
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68521608a2bc832a8dc419fb9f25dbad