### PR TITLE
Add devices and settings pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,8 @@ import { AuthProvider } from '@/context/AuthContext';
 import theme from '@/theme';
 import './App.css';
 import Dashboard from '@/pages/Dashboard';
+import Devices from '@/pages/Devices';
+import Settings from '@/pages/Settings';
 import { FC } from 'react';
 
 const App: FC = () => {
@@ -20,6 +22,8 @@ const App: FC = () => {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/devices" element={<Devices />} />
+            <Route path="/settings" element={<Settings />} />
             <Route path="/profile" element={
               <ProtectedRoute>
                 <Container maxWidth="sm" sx={{ mt: 4 }}>

--- a/client/src/pages/Devices/index.tsx
+++ b/client/src/pages/Devices/index.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState, FC } from 'react';
+import { Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, TableContainer, Paper, CircularProgress } from '@mui/material';
+import api from '@/services/api';
+import { Device } from '@/types';
+
+const Devices: FC = () => {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadDevices = async () => {
+      try {
+        const data = await api.fetchDevices();
+        setDevices(data);
+      } catch (err) {
+        console.error('Failed to load devices', err);
+        setError('Failed to load devices');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDevices();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Devices
+      </Typography>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>IP Address</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Last Seen</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {devices.map(device => (
+              <TableRow key={device.deviceId} hover>
+                <TableCell>{device.deviceId}</TableCell>
+                <TableCell>{device.name || `Device ${device.deviceId}`}</TableCell>
+                <TableCell>{device.type || 'N/A'}</TableCell>
+                <TableCell>{device.ipAddress}</TableCell>
+                <TableCell>{device.status ? 'Online' : 'Offline'}</TableCell>
+                <TableCell>{new Date(device.lastSeen).toLocaleString()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default Devices;

--- a/client/src/pages/Settings/index.tsx
+++ b/client/src/pages/Settings/index.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+import ModelControls from '@/components/ModelControls';
+
+const Settings: FC = () => {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Settings
+      </Typography>
+      <ModelControls />
+    </Box>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- create a Devices page that lists all devices
- add Settings page using existing model controls component
- register routes `/devices` and `/settings`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685323a84e44832aadad89eb3d60e2a8