### PR TITLE
Add model settings persistence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,8 @@ import { AuthProvider } from '@/context/AuthContext';
 import theme from '@/theme';
 import './App.css';
 import Dashboard from '@/pages/Dashboard';
+import Devices from '@/pages/Devices';
+import Settings from '@/pages/Settings';
 import { FC } from 'react';
 
 const App: FC = () => {
@@ -20,6 +22,8 @@ const App: FC = () => {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/devices" element={<Devices />} />
+            <Route path="/settings" element={<Settings />} />
             <Route path="/profile" element={
               <ProtectedRoute>
                 <Container maxWidth="sm" sx={{ mt: 4 }}>

--- a/client/src/pages/Devices/index.tsx
+++ b/client/src/pages/Devices/index.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState, FC } from 'react';
+import { Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, TableContainer, Paper, CircularProgress } from '@mui/material';
+import api from '@/services/api';
+import { Device } from '@/types';
+
+const Devices: FC = () => {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadDevices = async () => {
+      try {
+        const data = await api.fetchDevices();
+        setDevices(data);
+      } catch (err) {
+        console.error('Failed to load devices', err);
+        setError('Failed to load devices');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDevices();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Devices
+      </Typography>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>IP Address</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Last Seen</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {devices.map(device => (
+              <TableRow key={device.deviceId} hover>
+                <TableCell>{device.deviceId}</TableCell>
+                <TableCell>{device.name || `Device ${device.deviceId}`}</TableCell>
+                <TableCell>{device.type || 'N/A'}</TableCell>
+                <TableCell>{device.ipAddress}</TableCell>
+                <TableCell>{device.status ? 'Online' : 'Offline'}</TableCell>
+                <TableCell>{new Date(device.lastSeen).toLocaleString()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default Devices;

--- a/client/src/pages/Settings/index.tsx
+++ b/client/src/pages/Settings/index.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+import ModelControls from '@/components/ModelControls';
+
+const Settings: FC = () => {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Settings
+      </Typography>
+      <ModelControls />
+    </Box>
+  );
+};
+
+export default Settings;

--- a/server2/tests/evaluate_models.py
+++ b/server2/tests/evaluate_models.py
@@ -1,0 +1,63 @@
+"""Model Evaluation Script
+
+Loads a sample of traffic data from the local SQLite database and runs the
+anomaly detection models to evaluate them. Detected anomalies along with the
+methods that flagged them and relevant information are printed to the console.
+"""
+
+import os
+import sys
+
+# Ensure the server2 package is on the path when running directly
+CURRENT_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import pandas as pd
+from ml.anomaly_detector import detect_anomalies
+from utils.database import get_db_connection
+
+
+def evaluate(limit: int = 200, threshold: float = 0.7, model: str = "both") -> None:
+    """Evaluate the anomaly detection models.
+
+    Parameters
+    ----------
+    limit : int
+        Number of traffic records to analyse.
+    threshold : float
+        Threshold to use when determining anomalies.
+    model : str
+        Which model to use: 'isolation_forest', 'lof', or 'both'.
+    """
+    conn = get_db_connection()
+    df = pd.read_sql_query("SELECT * FROM traffic LIMIT ?", conn, params=(limit,))
+    conn.close()
+
+    anomalies = detect_anomalies(df.to_dict(orient="records"))
+
+    if not anomalies:
+        print("No anomalies detected.")
+        return
+
+    print(f"Detected {len(anomalies)} anomalies:\n")
+    for row in anomalies:
+        methods = []
+        if model in ("isolation_forest", "both") and any(
+            algo == "Isolation Forest" for algo in row.get("anomaly_type", [])
+        ):
+            methods.append("Isolation Forest")
+        if model in ("lof", "both") and any(
+            algo == "Local Outlier Factor" for algo in row.get("anomaly_type", [])
+        ):
+            methods.append("Local Outlier Factor")
+        score = row.get("confidence", 0.0)
+        print(
+            f"[{row['timestamp']}] Device {row['device_id']} src={row.get('src_ip','N/A')} -> {row.get('dst_ip','N/A')} | "
+            f"Score: {score:.3f} | Methods: {', '.join(methods)}"
+        )
+
+
+if __name__ == "__main__":
+    evaluate()

--- a/server2/utils/database.py
+++ b/server2/utils/database.py
@@ -115,6 +115,35 @@ def init_db():
             roles TEXT
         )
         ''')
+
+        # Create settings table to store model configuration
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        ''')
+
+        # Insert default settings if missing
+        cursor.execute("SELECT COUNT(*) as cnt FROM settings WHERE key = 'anomaly_threshold'")
+        if cursor.fetchone()["cnt"] == 0:
+            cursor.execute(
+                "INSERT INTO settings (key, value) VALUES ('anomaly_threshold', ?)",
+                ('0.7',)
+            )
+
+        cursor.execute("SELECT COUNT(*) as cnt FROM settings WHERE key = 'current_model'")
+        if cursor.fetchone()["cnt"] == 0:
+            cursor.execute(
+                "INSERT INTO settings (key, value) VALUES ('current_model', 'both')"
+            )
+
+        cursor.execute("SELECT COUNT(*) as cnt FROM settings WHERE key = 'last_model_training'")
+        if cursor.fetchone()["cnt"] == 0:
+            cursor.execute(
+                "INSERT INTO settings (key, value) VALUES ('last_model_training', ?)",
+                (datetime.now().isoformat(),)
+            )
         
         conn.commit()
 


### PR DESCRIPTION
## Summary
- create a settings table in the SQLite database to store model metadata
- register default values for threshold and model when initializing the DB
- keep new Devices and Settings pages from previous work
- add a server-side script to evaluate the anomaly detection models

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685323a84e44832aadad89eb3d60e2a8